### PR TITLE
don't panic on unsupported type

### DIFF
--- a/reflectwalk.go
+++ b/reflectwalk.go
@@ -5,6 +5,7 @@
 package reflectwalk
 
 import (
+	"fmt"
 	"reflect"
 )
 
@@ -121,7 +122,7 @@ func walk(v reflect.Value, w interface{}) error {
 
 		fallthrough
 	default:
-		panic("unsupported type: " + k.String())
+		return fmt.Errorf("unsupported type: %s", k.String())
 	}
 }
 


### PR DESCRIPTION
In Terraform, `make` fails because reflectwalk occurs panic.

```
--- FAIL: TestApply_vars (0.00 seconds)
panic: unsupported type: invalid [recovered]
        panic: unsupported type: invalid

goroutine 168 [running]:
runtime.panic(0x5c18a0, 0xc2080fa240)
        /usr/lib/go/src/pkg/runtime/panic.c:279 +0xf5
testing.func·006()
        /usr/lib/go/src/pkg/testing/testing.go:416 +0x176
runtime.panic(0x5c18a0, 0xc2080fa240)
        /usr/lib/go/src/pkg/runtime/panic.c:248 +0x18d
github.com/mitchellh/reflectwalk.walk(0x0, 0x0, 0x0, 0x0, 0x62da80, 0xc208090310, 0x0, 0x0)
        /tmp/gopath/src/github.com/mitchellh/reflectwalk/reflectwalk.go:124 +0x2ba
github.com/mitchellh/reflectwalk.Walk(0x0, 0x0, 0x62da80, 0xc208090310, 0x0, 0x0)
        /tmp/gopath/src/github.com/mitchellh/reflectwalk/reflectwalk.go:74 +0x19f
github.com/hashicorp/terraform/config.(*Config).Validate(0xc20804a400, 0x0, 0x0)
        /tmp/gopath/src/github.com/hashicorp/terraform/config/config.go:130 +0x22fb
github.com/hashicorp/terraform/command.(*Meta).Context(0xc2080905b0, 0xc20801bc20, 0x4f, 0xc2080fa430, 0x10, 0x17, 0x64d8b0, 0x0, 0x0)
        /tmp/gopath/src/github.com/hashicorp/terraform/command/meta.go:91 +0x4c3
github.com/hashicorp/terraform/command.(*ApplyCommand).Run(0xc2080905b0, 0xc20801bcb0, 0x1, 0x1, 0x989570)
        /tmp/gopath/src/github.com/hashicorp/terraform/command/apply.go:71 +0x5ff
github.com/hashicorp/terraform/command.TestApply_vars(0xc208049200)
        /tmp/gopath/src/github.com/hashicorp/terraform/command/apply_test.go:604 +0x27f
testing.tRunner(0xc208049200, 0x97adc8)
        /usr/lib/go/src/pkg/testing/testing.go:422 +0x8b
created by testing.RunTests
        /usr/lib/go/src/pkg/testing/testing.go:504 +0x8db
```
