### PR TITLE
nit: Expression list in switch instead of fallthroughs

### DIFF
--- a/reflectwalk.go
+++ b/reflectwalk.go
@@ -113,17 +113,7 @@ func walk(v reflect.Value, w interface{}) (err error) {
 
 	switch k {
 	// Primitives
-	case reflect.Bool:
-		fallthrough
-	case reflect.Chan:
-		fallthrough
-	case reflect.Func:
-		fallthrough
-	case reflect.Int:
-		fallthrough
-	case reflect.String:
-		fallthrough
-	case reflect.Invalid:
+	case reflect.Bool, reflect.Chan, reflect.Func, reflect.Int, reflect.String, reflect.Invalid:
 		err = walkPrimitive(originalV, w)
 		return
 	case reflect.Map:


### PR DESCRIPTION
Just a little more concise. Seems y'all do this consistently though, so maybe there's a reason to avoid expression lists i'm not aware of...or it's a stylistic preference y'all have agreed on?