### PR TITLE
reflectwalk panics on a map with pointers

### DIFF
--- a/reflectwalk.go
+++ b/reflectwalk.go
@@ -4,9 +4,7 @@
 // those elements.
 package reflectwalk
 
-import (
-	"reflect"
-)
+import "reflect"
 
 // PrimitiveWalker implementations are able to handle primitive values
 // within complex structures. Primitive values are numbers, strings,
@@ -144,6 +142,12 @@ func walkMap(v reflect.Value, w interface{}) error {
 
 	for _, k := range v.MapKeys() {
 		kv := v.MapIndex(k)
+
+		// if the map value type is an interface, we need to extract the Elem
+		// for the next call to walk
+		if kv.Kind() == reflect.Interface {
+			kv = kv.Elem()
+		}
 
 		if mw, ok := w.(MapWalker); ok {
 			if err := mw.MapElem(v, k, kv); err != nil {

--- a/reflectwalk_test.go
+++ b/reflectwalk_test.go
@@ -65,8 +65,8 @@ func (t *TestPrimitiveReplaceWalker) Primitive(v reflect.Value) error {
 
 type TestMapWalker struct {
 	MapVal reflect.Value
-	Keys   []string
-	Values []string
+	Keys   map[string]bool
+	Values map[string]bool
 }
 
 func (t *TestMapWalker) Map(m reflect.Value) error {
@@ -76,12 +76,12 @@ func (t *TestMapWalker) Map(m reflect.Value) error {
 
 func (t *TestMapWalker) MapElem(m, k, v reflect.Value) error {
 	if t.Keys == nil {
-		t.Keys = make([]string, 0, 1)
-		t.Values = make([]string, 0, 1)
+		t.Keys = make(map[string]bool)
+		t.Values = make(map[string]bool)
 	}
 
-	t.Keys = append(t.Keys, k.Interface().(string))
-	t.Values = append(t.Values, v.Interface().(string))
+	t.Keys[k.Interface().(string)] = true
+	t.Values[v.Interface().(string)] = true
 	return nil
 }
 
@@ -294,12 +294,12 @@ func TestWalk_Map(t *testing.T) {
 		t.Fatalf("Bad: %#v", w.MapVal.Interface())
 	}
 
-	expectedK := []string{"foo", "bar"}
+	expectedK := map[string]bool{"foo": true, "bar": true}
 	if !reflect.DeepEqual(w.Keys, expectedK) {
 		t.Fatalf("Bad keys: %#v", w.Keys)
 	}
 
-	expectedV := []string{"foov", "barv"}
+	expectedV := map[string]bool{"foov": true, "barv": true}
 	if !reflect.DeepEqual(w.Values, expectedV) {
 		t.Fatalf("Bad values: %#v", w.Values)
 	}
@@ -378,8 +378,8 @@ func TestWalk_Struct(t *testing.T) {
 
 type TestInterfaceMapWalker struct {
 	MapVal reflect.Value
-	Keys   []string
-	Values []interface{}
+	Keys   map[string]bool
+	Values map[interface{}]bool
 }
 
 func (t *TestInterfaceMapWalker) Map(m reflect.Value) error {
@@ -389,12 +389,12 @@ func (t *TestInterfaceMapWalker) Map(m reflect.Value) error {
 
 func (t *TestInterfaceMapWalker) MapElem(m, k, v reflect.Value) error {
 	if t.Keys == nil {
-		t.Keys = make([]string, 0, 1)
-		t.Values = make([]interface{}, 0, 1)
+		t.Keys = make(map[string]bool)
+		t.Values = make(map[interface{}]bool)
 	}
 
-	t.Keys = append(t.Keys, k.Interface().(string))
-	t.Values = append(t.Values, v.Interface())
+	t.Keys[k.Interface().(string)] = true
+	t.Values[v.Interface()] = true
 	return nil
 }
 
@@ -413,6 +413,7 @@ func TestWalk_MapWithPointers(t *testing.T) {
 			"foo": &a,
 			"bar": &b,
 			"baz": 11,
+			"zab": (*int)(nil),
 		},
 	}
 
@@ -425,12 +426,12 @@ func TestWalk_MapWithPointers(t *testing.T) {
 		t.Fatalf("Bad: %#v", w.MapVal.Interface())
 	}
 
-	expectedK := []string{"foo", "bar", "baz"}
+	expectedK := map[string]bool{"foo": true, "bar": true, "baz": true, "zab": true}
 	if !reflect.DeepEqual(w.Keys, expectedK) {
 		t.Fatalf("Bad keys: %#v", w.Keys)
 	}
 
-	expectedV := []interface{}{&a, &b, 11}
+	expectedV := map[interface{}]bool{&a: true, &b: true, 11: true, (*int)(nil): true}
 	if !reflect.DeepEqual(w.Values, expectedV) {
 		t.Fatalf("Bad values: %#v", w.Values)
 	}


### PR DESCRIPTION
Pointers in a map need to be extracted from an interface before the next call to walk, so that they are acted on appropriately. 