### PR TITLE
Dereference interfaces at the top of walk

### DIFF
--- a/reflectwalk_test.go
+++ b/reflectwalk_test.go
@@ -192,6 +192,23 @@ func TestWalk_Basic_Replace(t *testing.T) {
 	}
 }
 
+func TestWalk_Basic_ReplaceInterface(t *testing.T) {
+	w := new(TestPrimitiveReplaceWalker)
+
+	type S struct {
+		Foo []interface{}
+	}
+
+	data := &S{
+		Foo: []interface{}{"foo"},
+	}
+
+	err := Walk(data, w)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestWalk_EnterExit(t *testing.T) {
 	w := new(TestEnterExitWalker)
 


### PR DESCRIPTION
This reverts #9 and #10 and moves that handling to the top of walk.
Interface handling should be handled globally and by dereferencing early
we were hitting issues where the consumer may actually WANT to have the
pointer values.

I wrote a test to showcase this usage.

Without this, Terraform tests actually fail with #9 and #10