### PR TITLE
Add InterfaceWalker

### DIFF
--- a/reflectwalk.go
+++ b/reflectwalk.go
@@ -19,6 +19,12 @@ type PrimitiveWalker interface {
 	Primitive(reflect.Value) error
 }
 
+// InterfaceWalker implementations are able to handle interface values as they
+// are encountered during the walk.
+type InterfaceWalker interface {
+	Interface(reflect.Value) error
+}
+
 // MapWalker implementations are able to handle individual elements
 // found within a map structure.
 type MapWalker interface {
@@ -106,8 +112,15 @@ func walk(v reflect.Value, w interface{}) (err error) {
 
 	for {
 		if pointerV.Kind() == reflect.Interface {
+			if iw, ok := w.(InterfaceWalker); ok {
+				if err = iw.Interface(pointerV); err != nil {
+					return
+				}
+			}
+
 			pointerV = pointerV.Elem()
 		}
+
 		if pointerV.Kind() == reflect.Ptr {
 			pointer = true
 			v = reflect.Indirect(pointerV)

--- a/reflectwalk_test.go
+++ b/reflectwalk_test.go
@@ -58,6 +58,15 @@ func (t *TestPrimitiveWalker) Primitive(v reflect.Value) error {
 	return nil
 }
 
+type TestInterfaceWalker struct {
+	Types []reflect.Type
+}
+
+func (t *TestInterfaceWalker) Interface(v reflect.Value) error {
+	t.Types = append(t.Types, v.Type())
+	return nil
+}
+
 type TestPrimitiveCountWalker struct {
 	Count int
 }
@@ -609,5 +618,31 @@ func TestWalk_StructWithSkipEntry(t *testing.T) {
 		if s.Fields != 1 {
 			t.Fatalf("bad: %d", s.Fields)
 		}
+	}
+}
+
+func TestWalk_walkInterface(t *testing.T) {
+	w := new(TestInterfaceWalker)
+
+	type S struct {
+		A interface{}
+		B fmt.Stringer
+		C error
+	}
+
+	data := &S{}
+
+	err := Walk(data, w)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := []reflect.Type{
+		reflect.TypeOf((*interface{})(nil)).Elem(),
+		reflect.TypeOf((*fmt.Stringer)(nil)).Elem(),
+		reflect.TypeOf((*error)(nil)).Elem(),
+	}
+	if !reflect.DeepEqual(w.Types, expected) {
+		t.Fatalf("bad: %#v", w.Types)
 	}
 }


### PR DESCRIPTION
It may be useful at times to report the specific interface type and
location to the walker. An InterfaceWalker implementation will receive
the interface value before reflectwalk steps into the value contained in
the interface.

Completes #13 