### PR TITLE
Allow for the map value to be changed in the MapElem call

### DIFF
--- a/reflectwalk.go
+++ b/reflectwalk.go
@@ -230,7 +230,8 @@ func walkMap(v reflect.Value, w interface{}) error {
 			ew.Enter(MapValue)
 		}
 
-		if err := walk(kv, w); err != nil {
+		// get the map value again as it may have changed in the MapElem call
+		if err := walk(v.MapIndex(k), w); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Before we would walk the already retrieve value even when it had been updated.